### PR TITLE
Add missing spaces in alert description

### DIFF
--- a/events_types.go
+++ b/events_types.go
@@ -761,7 +761,7 @@ func (ev *EventAlertType) String() string {
 	} else {
 		res = "High"
 	}
-	res += fmt.Sprintf("%s usage on container %s", d.Metric, d.SenderName)
+	res += fmt.Sprintf(" %s usage on container %s ", d.Metric, d.SenderName)
 	if ev.TypeData.Activated {
 		res += "triggered"
 	} else {


### PR DESCRIPTION
I will update the CLI when this is merged

Related to Scalingo/cli#386