### PR TITLE
Expand Operation API use types and new helper method

### DIFF
--- a/operations.go
+++ b/operations.go
@@ -3,6 +3,7 @@ package scalingo
 import (
 	"time"
 
+	httpclient "github.com/Scalingo/go-scalingo/http"
 	"gopkg.in/errgo.v1"
 )
 
@@ -12,22 +13,49 @@ type OperationsService interface {
 
 var _ OperationsService = (*Client)(nil)
 
+type OperationStatus string
+
+const (
+	OperationStatusPending OperationStatus = "pending"
+	OperationStatusDone    OperationStatus = "done"
+	OperationStatusRunning OperationStatus = "running"
+	OperationStatusError   OperationStatus = "error"
+)
+
+type OperationType string
+
+const (
+	OperationTypeScale OperationType = "scale"
+	OperationTypeStart OperationType = "start"
+)
+
 type OperationResponse struct {
 	Op Operation `json:"operation"`
 }
 
 type Operation struct {
-	ID         string    `json:"id"`
-	AppID      string    `json:"app_id"`
-	CreatedAt  time.Time `json:"created_at"`
-	FinishedAt time.Time `json:"finished_at"`
-	Status     string    `json:"status"`
-	Type       string    `json:"type"`
-	Error      string    `json:"error"`
+	ID         string          `json:"id"`
+	AppID      string          `json:"app_id"`
+	CreatedAt  time.Time       `json:"created_at"`
+	FinishedAt time.Time       `json:"finished_at"`
+	Status     OperationStatus `json:"status"`
+	Type       OperationType   `json:"type"`
+	Error      string          `json:"error"`
 }
 
 func (op *Operation) ElapsedDuration() float64 {
 	return op.FinishedAt.Sub(op.CreatedAt).Seconds()
+}
+
+func (c *Client) OperationsShowFromURL(url string) (*Operation, error) {
+	var opRes OperationResponse
+	err := c.ScalingoAPI().DoRequest(&httpclient.APIRequest{
+		Method: "GET", URL: url,
+	}, &opRes)
+	if err != nil {
+		return nil, errgo.Mask(err)
+	}
+	return &opRes.Op, nil
 }
 
 func (c *Client) OperationsShow(app string, opID string) (*Operation, error) {


### PR DESCRIPTION
Fixes #91

Operation URL is fetched from `AppsRestart()`/`AppsScale()` headers

So I think it's usefull not to oblige the client to parse the URL to put the right IDs