### PR TITLE
No need to know the name of the notifier type, just the platform ID when creating or updating a notifier

### DIFF
--- a/notifier_types.go
+++ b/notifier_types.go
@@ -30,9 +30,16 @@ type Notifier struct {
 // Struct used to serialize a notifier
 type NotifierOutput struct {
 	*Notifier
-	SelectedEvents []string    `json:"selected_events,omitempty"`
-	TypeData       interface{} `json:"type_data,omitempty"`
-	RawTypeData    omit        `json:",omitempty"` // Will always be empty and not serialized
+	SelectedEvents []string               `json:"selected_events,omitempty"`
+	TypeData       NotifierTypeDataParams `json:"type_data,omitempty"`
+	RawTypeData    omit                   `json:",omitempty"` // Will always be empty and not serialized
+}
+
+type NotifierTypeDataParams struct {
+	WebhookURL  string   `json:"webhook_url,omitempty"`
+	Emails      []string `json:"emails,omitempty"`
+	UserIDs     []string `json:"user_ids,omitempty"`
+	PhoneNumber string   `json:"phone_number",omitempty`
 }
 
 type NotifierType string
@@ -226,11 +233,23 @@ func NewDetailedNotifier(notifierType string, params NotifierParams) DetailedNot
 	return specializedNotifier
 }
 
-func NewOutputNotifier(notifierType string, params NotifierParams) NotifierOutput {
-	detailedNotifier := NewDetailedNotifier(notifierType, params)
+// newOutputNotifier prepares the payload to send to the API to
+// create or update a notifier
+func newOutputNotifier(params NotifierParams) NotifierOutput {
 	res := NotifierOutput{
-		Notifier:       detailedNotifier.GetNotifier(),
-		TypeData:       detailedNotifier.TypeDataPtr(),
+		Notifier: &Notifier{
+			Active:        params.Active,
+			Name:          params.Name,
+			PlatformID:    params.PlatformID,
+			SendAllAlerts: params.SendAllAlerts,
+			SendAllEvents: params.SendAllEvents,
+		},
+		TypeData: NotifierTypeDataParams{
+			Emails:      params.Emails,
+			UserIDs:     params.UserIDs,
+			WebhookURL:  params.WebhookURL,
+			PhoneNumber: params.PhoneNumber,
+		},
 		SelectedEvents: params.SelectedEvents,
 	}
 	return res

--- a/notifier_types.go
+++ b/notifier_types.go
@@ -39,7 +39,7 @@ type NotifierTypeDataParams struct {
 	WebhookURL  string   `json:"webhook_url,omitempty"`
 	Emails      []string `json:"emails,omitempty"`
 	UserIDs     []string `json:"user_ids,omitempty"`
-	PhoneNumber string   `json:"phone_number",omitempty`
+	PhoneNumber string   `json:"phone_number,omitempty"`
 }
 
 type NotifierType string

--- a/notifiers.go
+++ b/notifiers.go
@@ -7,9 +7,9 @@ import (
 
 type NotifiersService interface {
 	NotifiersList(app string) (Notifiers, error)
-	NotifierProvision(app, notifierType string, params NotifierParams) (*Notifier, error)
+	NotifierProvision(app string, params NotifierParams) (*Notifier, error)
 	NotifierByID(app, ID string) (*Notifier, error)
-	NotifierUpdate(app, ID, notifierType string, params NotifierParams) (*Notifier, error)
+	NotifierUpdate(app, ID string, params NotifierParams) (*Notifier, error)
 	NotifierDestroy(app, ID string) error
 }
 
@@ -58,9 +58,9 @@ func (c *Client) NotifiersList(app string) (Notifiers, error) {
 	return notifiers, nil
 }
 
-func (c *Client) NotifierProvision(app, notifierType string, params NotifierParams) (*Notifier, error) {
+func (c *Client) NotifierProvision(app string, params NotifierParams) (*Notifier, error) {
 	var notifierRes notifierRequestRes
-	notifier := NewOutputNotifier(notifierType, params)
+	notifier := newOutputNotifier(params)
 	notifierRequestParams := &notifierRequestParams{notifier}
 
 	err := c.ScalingoAPI().SubresourceAdd("apps", app, "notifiers", notifierRequestParams, &notifierRes)
@@ -81,9 +81,9 @@ func (c *Client) NotifierByID(app, ID string) (*Notifier, error) {
 	return &notifierRes.Notifier, nil
 }
 
-func (c *Client) NotifierUpdate(app, ID, notifierType string, params NotifierParams) (*Notifier, error) {
+func (c *Client) NotifierUpdate(app, ID string, params NotifierParams) (*Notifier, error) {
 	var notifierRes notifierRequestRes
-	notifier := NewOutputNotifier(notifierType, params)
+	notifier := newOutputNotifier(params)
 	notifierRequestParams := &notifierRequestParams{notifier}
 
 	debug.Printf("[Notifier params]\n%+v", notifier)


### PR DESCRIPTION
Fixes #97