### PR TITLE
Add StaticTokenGenerator for AuthAPI, to use a JWT Token instead of the basic token.

### DIFF
--- a/client.go
+++ b/client.go
@@ -140,7 +140,11 @@ func (c *Client) AuthAPI() http.Client {
 	if c.authClient != nil {
 		return c.authClient
 	}
+
 	var tokenGenerator http.TokenGenerator
+	if c.config.StaticTokenGenerator != nil {
+		tokenGenerator = c.config.StaticTokenGenerator
+	}
 	if len(c.config.APIToken) != 0 {
 		tokenGenerator = http.NewAPITokenGenerator(c, c.config.APIToken)
 	}


### PR DESCRIPTION
Close #153 