### PR TITLE
[Migrations] Rename scheduled to created status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## ToBeReleased
 
+* Rename `scheduled` to `created` in RegionMigrationStatus list
 * Add `aborting` status to the list of RegionMigrationStatus
 
 ## v4.3.1

--- a/region_migrations.go
+++ b/region_migrations.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	RegionMigrationStatusScheduled        RegionMigrationStatus = "scheduled"
+	RegionMigrationStatusCreated          RegionMigrationStatus = "created"
 	RegionMigrationStatusPreflightSuccess RegionMigrationStatus = "preflight-success"
 	RegionMigrationStatusPreflightError   RegionMigrationStatus = "preflight-error"
 	RegionMigrationStatusRunning          RegionMigrationStatus = "running"


### PR DESCRIPTION
This change was made when we were adding the run endpoints https://github.com/Scalingo/storky/commit/7501cb13c2ff359846df83a44fb04e77411faee3