### PR TITLE
Fix Who created an event for restart and edit_variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## ToBeReleased
 
 * Fix support for `addon_updated` and `start_region_migration` event types
+* Fix who created a `restart` or `edit_variable` event types
 
 ## v4.4.0
 

--- a/README.md
+++ b/README.md
@@ -24,5 +24,7 @@ instance if your event type is named `my_event`:
         type `EventMyEventTypeData`.
     * Implement function `String` for `EventMyEventType`
     * Add support for this event type in the `Specialize` function
+    * [optional] Implement `Who` function for `EventMyEventType`. E.g. if the
+        event type can be created by an addon.
 * `events_boilerplate.go`: implement the `TypeDataPtr` function for the new
     `EventMyEventType` structure.

--- a/events_structs.go
+++ b/events_structs.go
@@ -218,9 +218,17 @@ func (ev *EventRestartType) String() string {
 	return fmt.Sprintf("containers have been restarted")
 }
 
+func (ev *EventRestartType) Who() string {
+	if ev.TypeData.AddonName != "" {
+		return fmt.Sprintf("Addon %s", ev.TypeData.AddonName)
+	} else {
+		return ev.Who()
+	}
+}
+
 type EventRestartTypeData struct {
-	Scope         []string `json:"scope"`
-	AddonProvider string   `json:"addon_provider"`
+	Scope     []string `json:"scope"`
+	AddonName string   `json:"addon_name"`
 }
 
 type EventStopAppType struct {
@@ -644,7 +652,8 @@ func (ev *EventEditVariableType) String() string {
 
 type EventEditVariableTypeData struct {
 	EventVariable
-	OldValue string `json:"old_value"`
+	OldValue  string `json:"old_value"`
+	AddonName string `json:"addon_name"`
 }
 
 type EventEditVariablesType struct {
@@ -664,6 +673,14 @@ func (ev *EventEditVariablesType) String() string {
 		res += fmt.Sprintf(" %s removed", ev.TypeData.DeletedVars.Names())
 	}
 	return res
+}
+
+func (ev *EventEditVariableType) Who() string {
+	if ev.TypeData.AddonName != "" {
+		return fmt.Sprintf("Addon %s", ev.TypeData.AddonName)
+	} else {
+		return ev.Who()
+	}
 }
 
 type EventEditVariablesTypeData struct {


### PR DESCRIPTION
The event `restart` and `edit_variable` might be created by an addon. It currently lacks the `Who` method for these events.

Related to Scalingo/cli#530