### PR TITLE
Update GET /log_drains to return object with array instead of directly an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## ToBeReleased
 
+* Update GET /log_drains route to return object instead of array
+
 ## v4.5.4
 
 * Fix infinite recursion on some events

--- a/log_drains.go
+++ b/log_drains.go
@@ -29,13 +29,17 @@ type LogDrainRes struct {
 	Drain LogDrain `json:"drain"`
 }
 
+type LogDrainsRes struct {
+	Drains []LogDrain `json:"drains"`
+}
+
 func (c *Client) LogDrainsList(app string) ([]LogDrain, error) {
-	var logDrainsRes []LogDrain
+	var logDrainsRes LogDrainsRes
 	err := c.ScalingoAPI().SubresourceList("apps", app, "log_drains", nil, &logDrainsRes)
 	if err != nil {
 		return nil, errgo.Notef(err, "fail to list the log drains")
 	}
-	return logDrainsRes, nil
+	return logDrainsRes.Drains, nil
 }
 
 type LogDrainAddParams struct {

--- a/log_drains_test.go
+++ b/log_drains_test.go
@@ -33,12 +33,13 @@ func TestLogDrainsClient(t *testing.T) {
 			},
 			expectedEndpoint: "/v1/apps/my-app/log_drains",
 			expectedMethod:   "GET",
-			response: []LogDrain{
-				{
-					AppID: logDrainID,
-					URL:   logDrainURL,
-				},
-			},
+			response: LogDrainsRes{
+				[]LogDrain{
+					{
+						AppID: logDrainID,
+						URL:   logDrainURL,
+					},
+				}},
 		},
 		{
 			action: "add",


### PR DESCRIPTION
Related to https://github.com/Scalingo/api/issues/1713
