### PR TITLE
Make API version prefix more easily configurable by user

### DIFF
--- a/client.go
+++ b/client.go
@@ -54,8 +54,11 @@ type ClientConfig struct {
 	Timeout             time.Duration
 	TLSConfig           *tls.Config
 	APIEndpoint         string
+	APIPrefix           string
 	AuthEndpoint        string
+	AuthPrefix          string
 	DatabaseAPIEndpoint string
+	DatabaseAPIPrefix   string
 	APIToken            string
 	Region              string
 	UserAgent           string
@@ -113,12 +116,16 @@ func (c *Client) ScalingoAPI() http.Client {
 	if len(c.config.APIToken) != 0 {
 		tokenGenerator = http.NewAPITokenGenerator(c, c.config.APIToken)
 	}
+	prefix := "/v1"
+	if c.config.APIPrefix != "" {
+		prefix = c.config.APIPrefix
+	}
 
 	return http.NewClient(http.ScalingoAPI, http.ClientConfig{
 		UserAgent:      c.config.UserAgent,
 		Timeout:        c.config.Timeout,
 		TLSConfig:      c.config.TLSConfig,
-		APIVersion:     "1",
+		APIConfig:      http.APIConfig{Prefix: prefix},
 		TokenGenerator: tokenGenerator,
 		Endpoint:       c.config.APIEndpoint,
 	})
@@ -128,9 +135,15 @@ func (c *Client) DBAPI(app, addon string) http.Client {
 	if c.dbClient != nil {
 		return c.dbClient
 	}
+
+	prefix := "/api"
+	if c.config.DatabaseAPIPrefix != "" {
+		prefix = c.config.DatabaseAPIPrefix
+	}
 	return http.NewClient(http.DBAPI, http.ClientConfig{
 		Timeout:        c.config.Timeout,
 		TLSConfig:      c.config.TLSConfig,
+		APIConfig:      http.APIConfig{Prefix: prefix},
 		TokenGenerator: http.NewAddonTokenGenerator(app, addon, c),
 		Endpoint:       c.config.DatabaseAPIEndpoint,
 	})
@@ -149,10 +162,14 @@ func (c *Client) AuthAPI() http.Client {
 		tokenGenerator = http.NewAPITokenGenerator(c, c.config.APIToken)
 	}
 
+	prefix := "/v1"
+	if c.config.AuthPrefix != "" {
+		prefix = c.config.AuthPrefix
+	}
 	return http.NewClient(http.AuthAPI, http.ClientConfig{
 		Timeout:        c.config.Timeout,
 		TLSConfig:      c.config.TLSConfig,
-		APIVersion:     "1",
+		APIConfig:      http.APIConfig{Prefix: prefix},
 		TokenGenerator: tokenGenerator,
 		Endpoint:       c.config.AuthEndpoint,
 	})

--- a/http/api_request.go
+++ b/http/api_request.go
@@ -16,11 +16,6 @@ import (
 	"gopkg.in/errgo.v1"
 )
 
-var (
-	defaultEndpoint   = "https://api.scalingo.com"
-	defaultAPIVersion = "1"
-)
-
 type APIRequest struct {
 	NoAuth      bool
 	URL         string

--- a/http/client.go
+++ b/http/client.go
@@ -15,21 +15,8 @@ const (
 	DBAPI       = "DATABASES_API"
 )
 
-var apisConfig = map[string]apiConfig{
-	AuthAPI: {
-		HasVersionPrefix: true,
-	},
-	ScalingoAPI: {
-		HasVersionPrefix: true,
-	},
-	DBAPI: {
-		Prefix: "/api",
-	},
-}
-
-type apiConfig struct {
-	HasVersionPrefix bool
-	Prefix           string
+type APIConfig struct {
+	Prefix string
 }
 
 type Client interface {
@@ -56,7 +43,7 @@ type ClientConfig struct {
 	UserAgent      string
 	Timeout        time.Duration
 	TLSConfig      *tls.Config
-	APIVersion     string
+	APIConfig      APIConfig
 	Endpoint       string
 	TokenGenerator TokenGenerator
 }
@@ -65,7 +52,7 @@ type client struct {
 	tokenGenerator TokenGenerator
 	endpoint       string
 	userAgent      string
-	apiConfig      apiConfig
+	apiConfig      APIConfig
 	httpClient     *http.Client
 	prefix         string
 }
@@ -78,28 +65,12 @@ func NewClient(api string, cfg ClientConfig) Client {
 		cfg.TLSConfig = &tls.Config{}
 	}
 
-	config := apisConfig[api]
-
-	if cfg.APIVersion == "" {
-		cfg.APIVersion = defaultAPIVersion
-	}
-
-	var prefix string
-
-	if config.HasVersionPrefix {
-		prefix = fmt.Sprintf("/v%v", cfg.APIVersion)
-	}
-
-	if config.Prefix != "" {
-		prefix = config.Prefix
-	}
-
 	c := client{
-		prefix:         prefix,
+		prefix:         cfg.APIConfig.Prefix,
 		endpoint:       cfg.Endpoint,
 		tokenGenerator: cfg.TokenGenerator,
 		userAgent:      cfg.UserAgent,
-		apiConfig:      config,
+		apiConfig:      cfg.APIConfig,
 		httpClient: &http.Client{
 			Timeout: cfg.Timeout,
 			Transport: &http.Transport{


### PR DESCRIPTION
Currently changing the /v1 prefix for the API endpoint was impossible but was required for internal usages of the API, this PR allows this