### PR TITLE
Add dependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    vendor: true
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+    allow:
+      - dependency-type: "all"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    vendor: true
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "friday"
+      day: "tuesday"
     allow:
       - dependency-type: "all"


### PR DESCRIPTION
The documentation talks about a `vendor` attribute (https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#vendor) but it has been rejected by Dependabot parser. And this blog post (https://github.blog/changelog/2020-10-19-dependabot-go-mod-tidy-and-vendor-support/) seems to indicate the `vendor` attribute is not needed. I suggest we try it like that.

https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#vendor

Fix [SG-77]

[SG-77]: https://scalingo.atlassian.net/browse/SG-77