### PR TITLE
Remove headers from Request of http.parseJSON returned error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+* Remove headers from `Request` of `http.parseJSON` returned error
+  [#199](https://github.com/Scalingo/go-scalingo/pull/199)
 * Add missing fields `Plan.SKU` (corresponding catalogue name)
   [#198](https://github.com/Scalingo/go-scalingo/pull/198) thanks @mackwic
 

--- a/http/api_request.go
+++ b/http/api_request.go
@@ -146,14 +146,16 @@ func (c *client) doRequest(req *http.Request) (*http.Response, error) {
 func parseJSON(res *http.Response, data interface{}) error {
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		return errgo.Newf("fail to read body of request %v, %v", res.Request, err)
+		reqErr := fmt.Sprintf("%v %v", res.Request.Method, res.Request.URL)
+		return errgo.Newf("fail to read body of request %v: %v", reqErr, err)
 	}
 
 	debug.Println(string(body))
 
 	err = json.Unmarshal(body, data)
 	if err != nil {
-		return errgo.Newf("fail to parse JSON of request %v, %v", res.Request, err)
+		reqErr := fmt.Sprintf("%v %v", res.Request.Method, res.Request.URL)
+		return errgo.Newf("fail to parse JSON of request %v: %v", reqErr, err)
 	}
 
 	return nil


### PR DESCRIPTION
[GRR-94]

This pollutes the log, does not give more information for debug, and leaks the JWT token 👎🏻 

Example of log:
```text
fail to parse JSON of subresource response: fail to parse JSON of request &{GET https://api.scalingo.com/v1/apps/test? HTTP/1.1 1 1 map[Accept:[application/json] Authorization:[Bearer ...] Content-Type:[application/json] User-Agent:[Scalingo Go Client]] <nil> <nil> 0 [] false api.scalingo.com map[] map[] <nil> map[] <nil> <nil> <nil> 0xc0001f3200}, json: cannot unmarshal string into Go value of type scalingo.App
```

[GRR-94]: https://scalingo.atlassian.net/browse/GRR-94