### PR TITLE
fix: restore previous AppsPs and rename AppsPs to AppsContainersPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 * feat(domain): add SSL status [#207](https://github.com/Scalingo/go-scalingo/pull/207)
 * feat: add user agent to auth and DB API requests [#206](https://github.com/Scalingo/go-scalingo/pull/206)
-* feat(event): add suport for notifier events [#205](https://github.com/Scalingo/go-scalingo/pull/205)
+* feat(event): add support for notifier events [#205](https://github.com/Scalingo/go-scalingo/pull/205)
 * Add `ContainersStop` to stop a running one-off container [#204](https://github.com/Scalingo/go-scalingo/pull/204)
-* Rename `AppsPs` to `AppsContainerTypes` [#204](https://github.com/Scalingo/go-scalingo/pull/204)
-* Add `AppsPs` to list all application's containers [#204](https://github.com/Scalingo/go-scalingo/pull/204)
+* Add `AppsContainersPs` to list all application's containers [#204](https://github.com/Scalingo/go-scalingo/pull/204) and [#208](https://github.com/Scalingo/go-scalingo/pull/208)
+* Add `AppsContainerTypes` and deprecate `AppsPs` [#204](https://github.com/Scalingo/go-scalingo/pull/204) and [#208](https://github.com/Scalingo/go-scalingo/pull/208)
 
 ## 4.12.0
 

--- a/apps.go
+++ b/apps.go
@@ -29,7 +29,9 @@ type AppsService interface {
 	AppsCreate(opts AppsCreateOpts) (*App, error)
 	AppsStats(app string) (*AppStatsRes, error)
 	AppsContainerTypes(app string) ([]ContainerType, error)
-	AppsPs(app string) ([]Container, error)
+	// Deprecated: Use AppsContainerTypes instead
+	AppsPs(app string) ([]ContainerType, error)
+	AppsContainersPs(app string) ([]Container, error)
 	AppsScale(app string, params *AppsScaleParams) (*http.Response, error)
 	AppsForceHTTPS(name string, enable bool) (*App, error)
 	AppsStickySession(name string, enable bool) (*App, error)
@@ -262,7 +264,12 @@ func (c *Client) AppsStats(app string) (*AppStatsRes, error) {
 	return &stats, nil
 }
 
-func (c *Client) AppsPs(app string) ([]Container, error) {
+// Deprecated: Use AppsContainerTypes instead
+func (c *Client) AppsPs(app string) ([]ContainerType, error) {
+	return c.AppsContainerTypes(app)
+}
+
+func (c *Client) AppsContainersPs(app string) ([]Container, error) {
 	var containersRes AppsPsRes
 	req := &httpclient.APIRequest{
 		Endpoint: "/apps/" + app + "/ps",

--- a/mocks_sig.json
+++ b/mocks_sig.json
@@ -3,7 +3,7 @@
   "github.com/Scalingo/go-scalingo.AddonProvidersService": "84 c0 e6 0e c4 9d 80 57 79 b4 47 c0 79 c8 2e 51 b9 f9 64 c9",
   "github.com/Scalingo/go-scalingo.AddonsService": "eb 27 12 ee 56 da 52 12 39 e8 63 86 c0 dd 96 68 48 91 36 10",
   "github.com/Scalingo/go-scalingo.AlertsService": "8f 72 2e 6a 5f 31 c7 26 7c 09 10 93 38 d2 eb 6e 5a 26 ed 62",
-  "github.com/Scalingo/go-scalingo.AppsService": "0d 01 ff b6 39 03 fe 5b 5c 0c 62 64 b3 9e 75 5e e9 5e 0e 7f",
+  "github.com/Scalingo/go-scalingo.AppsService": "f1 01 20 34 ac 43 fd 95 8a d2 cc 39 54 09 59 05 de 2b 66 b3",
   "github.com/Scalingo/go-scalingo.AutoscalersService": "fe 33 e3 88 66 3e 25 c1 40 79 fc 01 6c aa 19 5e ce f6 f1 e7",
   "github.com/Scalingo/go-scalingo.BackupsService": "fd c3 88 a9 d7 18 80 fa 25 a8 fc ca 9c a1 40 2e 2d 26 ea 36",
   "github.com/Scalingo/go-scalingo.CollaboratorsService": "f7 7e 83 62 5b 67 9c 6c aa 79 f5 94 c7 90 d8 3f f8 42 95 81",

--- a/scalingomock/api_mock.go
+++ b/scalingomock/api_mock.go
@@ -245,6 +245,21 @@ func (mr *MockAPIMockRecorder) AppsContainerTypes(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppsContainerTypes", reflect.TypeOf((*MockAPI)(nil).AppsContainerTypes), arg0)
 }
 
+// AppsContainersPs mocks base method.
+func (m *MockAPI) AppsContainersPs(arg0 string) ([]scalingo.Container, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AppsContainersPs", arg0)
+	ret0, _ := ret[0].([]scalingo.Container)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AppsContainersPs indicates an expected call of AppsContainersPs.
+func (mr *MockAPIMockRecorder) AppsContainersPs(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppsContainersPs", reflect.TypeOf((*MockAPI)(nil).AppsContainersPs), arg0)
+}
+
 // AppsCreate mocks base method.
 func (m *MockAPI) AppsCreate(arg0 scalingo.AppsCreateOpts) (*scalingo.App, error) {
 	m.ctrl.T.Helper()
@@ -305,10 +320,10 @@ func (mr *MockAPIMockRecorder) AppsList() *gomock.Call {
 }
 
 // AppsPs mocks base method.
-func (m *MockAPI) AppsPs(arg0 string) ([]scalingo.Container, error) {
+func (m *MockAPI) AppsPs(arg0 string) ([]scalingo.ContainerType, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AppsPs", arg0)
-	ret0, _ := ret[0].([]scalingo.Container)
+	ret0, _ := ret[0].([]scalingo.ContainerType)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/scalingomock/appsservice_mock.go
+++ b/scalingomock/appsservice_mock.go
@@ -50,6 +50,21 @@ func (mr *MockAppsServiceMockRecorder) AppsContainerTypes(arg0 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppsContainerTypes", reflect.TypeOf((*MockAppsService)(nil).AppsContainerTypes), arg0)
 }
 
+// AppsContainersPs mocks base method.
+func (m *MockAppsService) AppsContainersPs(arg0 string) ([]scalingo.Container, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AppsContainersPs", arg0)
+	ret0, _ := ret[0].([]scalingo.Container)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AppsContainersPs indicates an expected call of AppsContainersPs.
+func (mr *MockAppsServiceMockRecorder) AppsContainersPs(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppsContainersPs", reflect.TypeOf((*MockAppsService)(nil).AppsContainersPs), arg0)
+}
+
 // AppsCreate mocks base method.
 func (m *MockAppsService) AppsCreate(arg0 scalingo.AppsCreateOpts) (*scalingo.App, error) {
 	m.ctrl.T.Helper()
@@ -110,10 +125,10 @@ func (mr *MockAppsServiceMockRecorder) AppsList() *gomock.Call {
 }
 
 // AppsPs mocks base method.
-func (m *MockAppsService) AppsPs(arg0 string) ([]scalingo.Container, error) {
+func (m *MockAppsService) AppsPs(arg0 string) ([]scalingo.ContainerType, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AppsPs", arg0)
-	ret0, _ := ret[0].([]scalingo.Container)
+	ret0, _ := ret[0].([]scalingo.ContainerType)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
The PR #204 introduced an API change which would have require a new major release. But as stated in the Go module documentation (https://blog.golang.org/v2-go-modules):

> These kinds of changes require effort by downstream users to migrate their code to the new API, so they should not be made without careful consideration that the benefits outweigh the costs

In this situation, I don't think that the benefits outweigh the costs. Hence I'm reverting the API changes so that we don't break the API anymore.


Related to [OPSB-257]

[OPSB-257]: https://scalingo.atlassian.net/browse/OPSB-257