### PR TITLE
build(deps): replace deprecated github.com/dgrijalva/jwt-go with github.com/golang-jwt/jwt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * build(deps): bump github.com/golang/mock from 1.5.0 to 1.6.0
 * Add `DeploymentUUID` to the deployment event and fix a typo [#216](https://github.com/Scalingo/go-scalingo/pull/216)
 * build(deps): replace deprecated github.com/dgrijalva/jwt-go with github.com/golang-jwt/jwt
-* chore: update from Go 1.13 to 1.16
+* chore: update from Go 1.13 to 1.17
 
 ## 4.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * build(deps): bump github.com/golang/mock from 1.5.0 to 1.6.0
 * Add `DeploymentUUID` to the deployment event and fix a typo [#216](https://github.com/Scalingo/go-scalingo/pull/216)
+* build(deps): replace deprecated github.com/dgrijalva/jwt-go with github.com/golang-jwt/jwt
+* chore: update from Go 1.13 to 1.16
 
 ## 4.13.0
 

--- a/auth_mock.go
+++ b/auth_mock.go
@@ -9,7 +9,7 @@ import (
 
 	httpclient "github.com/Scalingo/go-scalingo/v4/http"
 	"github.com/Scalingo/go-scalingo/v4/http/httpmock"
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt/v4"
 	gomock "github.com/golang/mock/gomock"
 )
 

--- a/client_test.go
+++ b/client_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-scalingo/v4
 
-go 1.16
+go 1.17
 
 require (
 	github.com/golang-jwt/jwt/v4 v4.0.0
@@ -8,4 +8,10 @@ require (
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4
 	gopkg.in/errgo.v1 v1.0.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
 module github.com/Scalingo/go-scalingo/v4
 
-go 1.13
+go 1.16
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/golang-jwt/jwt/v4 v4.0.0
 	github.com/golang/mock v1.6.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,9 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/frankban/quicktest v1.2.2 h1:xfmOhhoH5fGPgbEAlhLpJH9p0z/0Qizio9osmvn9IUY=
 github.com/frankban/quicktest v1.2.2/go.mod h1:Qh/WofXFeiAFII1aEBu529AtJo6Zg2VHscnEsbBnJ20=
+github.com/golang-jwt/jwt/v4 v4.0.0 h1:RAqyYixv1p7uEnocuy8P1nru5wprCh/MH2BIlW5z5/o=
+github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42 h1:q3pnF5JFBNRz8sRD+IRj7Y6DMyYGTNqnZ9axTbSfoNI=

--- a/http/api_token_generator.go
+++ b/http/api_token_generator.go
@@ -3,8 +3,7 @@ package http
 import (
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
-
+	jwt "github.com/golang-jwt/jwt/v4"
 	errgo "gopkg.in/errgo.v1"
 )
 

--- a/http/api_token_generator_test.go
+++ b/http/api_token_generator_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/Scalingo/go-scalingo/v4/http/tokensservicemock"
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt/v4"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
As specified in [github.com/dgrijalva/jwt-go](https://github.com/dgrijalva/jwt-go) README, the repository is no longer maintained and has been replaced with [github.com/golang-jwt/jwt](https://github.com/golang-jwt/jwt). The [migration guide](https://github.com/golang-jwt/jwt/blob/main/MIGRATION_GUIDE.md) is rather simple, it should work as is.