### PR TITLE
Add pagination on the DeploymentList method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * fix(apps): typo on the `UpdatedAt` field of the Apps [#220](https://github.com/Scalingo/go-scalingo/pull/220)
 * fix(token): correctly deserialize the `ID` [#222](https://github.com/Scalingo/go-scalingo/pull/222)
 * feat(token): add the `LastUsedAt` field [#222](https://github.com/Scalingo/go-scalingo/pull/222)
+* feat(deployments): add the `DeploymentListWithPagination` method [#221](https://github.com/Scalingo/go-scalingo/pull/221)
 
 ## 4.13.1
 

--- a/mocks_sig.json
+++ b/mocks_sig.json
@@ -9,7 +9,7 @@
   "github.com/Scalingo/go-scalingo.CollaboratorsService": "f7 7e 83 62 5b 67 9c 6c aa 79 f5 94 c7 90 d8 3f f8 42 95 81",
   "github.com/Scalingo/go-scalingo.ContainersService": "99 3d 27 af 4a bb b2 96 d9 7a e9 1a 40 6b eb 66 bb 9b 72 03",
   "github.com/Scalingo/go-scalingo.CronTasksService": "fa a6 29 83 98 5e 10 22 8c 87 3f fb 91 35 cd fb f2 8b 89 de",
-  "github.com/Scalingo/go-scalingo.DeploymentsService": "ed 32 bd b6 2f 86 a6 10 a8 67 40 f5 94 02 dd ff 0b 3e cb a9",
+  "github.com/Scalingo/go-scalingo.DeploymentsService": "e3 3d 3b 12 fd 76 aa ac 2c 6b c4 75 bb 04 ee 11 cd 44 1f 48",
   "github.com/Scalingo/go-scalingo.DomainsService": "5b 41 a1 fb 96 6d 8b e9 2a 02 25 04 64 75 ca 23 45 ab ac da",
   "github.com/Scalingo/go-scalingo.EventsService": "61 1a ac 54 41 28 f4 7b 66 09 e1 fd 35 79 29 70 f2 a6 5a 61",
   "github.com/Scalingo/go-scalingo.KeysService": "0c 8e c5 b3 f6 66 f0 f2 77 00 69 1e a5 a5 df 25 d7 2e 70 37",

--- a/scalingomock/api_mock.go
+++ b/scalingomock/api_mock.go
@@ -704,6 +704,22 @@ func (mr *MockAPIMockRecorder) DeploymentList(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeploymentList", reflect.TypeOf((*MockAPI)(nil).DeploymentList), arg0)
 }
 
+// DeploymentListWithPagination mocks base method.
+func (m *MockAPI) DeploymentListWithPagination(arg0 string, arg1 scalingo.PaginationOpts) ([]*scalingo.Deployment, scalingo.PaginationMeta, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeploymentListWithPagination", arg0, arg1)
+	ret0, _ := ret[0].([]*scalingo.Deployment)
+	ret1, _ := ret[1].(scalingo.PaginationMeta)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// DeploymentListWithPagination indicates an expected call of DeploymentListWithPagination.
+func (mr *MockAPIMockRecorder) DeploymentListWithPagination(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeploymentListWithPagination", reflect.TypeOf((*MockAPI)(nil).DeploymentListWithPagination), arg0, arg1)
+}
+
 // DeploymentLogs mocks base method.
 func (m *MockAPI) DeploymentLogs(arg0 string) (*http0.Response, error) {
 	m.ctrl.T.Helper()

--- a/scalingomock/deploymentsservice_mock.go
+++ b/scalingomock/deploymentsservice_mock.go
@@ -13,30 +13,30 @@ import (
 	websocket "golang.org/x/net/websocket"
 )
 
-// MockDeploymentsService is a mock of DeploymentsService interface
+// MockDeploymentsService is a mock of DeploymentsService interface.
 type MockDeploymentsService struct {
 	ctrl     *gomock.Controller
 	recorder *MockDeploymentsServiceMockRecorder
 }
 
-// MockDeploymentsServiceMockRecorder is the mock recorder for MockDeploymentsService
+// MockDeploymentsServiceMockRecorder is the mock recorder for MockDeploymentsService.
 type MockDeploymentsServiceMockRecorder struct {
 	mock *MockDeploymentsService
 }
 
-// NewMockDeploymentsService creates a new mock instance
+// NewMockDeploymentsService creates a new mock instance.
 func NewMockDeploymentsService(ctrl *gomock.Controller) *MockDeploymentsService {
 	mock := &MockDeploymentsService{ctrl: ctrl}
 	mock.recorder = &MockDeploymentsServiceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDeploymentsService) EXPECT() *MockDeploymentsServiceMockRecorder {
 	return m.recorder
 }
 
-// Deployment mocks base method
+// Deployment mocks base method.
 func (m *MockDeploymentsService) Deployment(arg0, arg1 string) (*scalingo.Deployment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Deployment", arg0, arg1)
@@ -45,13 +45,13 @@ func (m *MockDeploymentsService) Deployment(arg0, arg1 string) (*scalingo.Deploy
 	return ret0, ret1
 }
 
-// Deployment indicates an expected call of Deployment
+// Deployment indicates an expected call of Deployment.
 func (mr *MockDeploymentsServiceMockRecorder) Deployment(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deployment", reflect.TypeOf((*MockDeploymentsService)(nil).Deployment), arg0, arg1)
 }
 
-// DeploymentList mocks base method
+// DeploymentList mocks base method.
 func (m *MockDeploymentsService) DeploymentList(arg0 string) ([]*scalingo.Deployment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeploymentList", arg0)
@@ -60,13 +60,29 @@ func (m *MockDeploymentsService) DeploymentList(arg0 string) ([]*scalingo.Deploy
 	return ret0, ret1
 }
 
-// DeploymentList indicates an expected call of DeploymentList
+// DeploymentList indicates an expected call of DeploymentList.
 func (mr *MockDeploymentsServiceMockRecorder) DeploymentList(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeploymentList", reflect.TypeOf((*MockDeploymentsService)(nil).DeploymentList), arg0)
 }
 
-// DeploymentLogs mocks base method
+// DeploymentListWithPagination mocks base method.
+func (m *MockDeploymentsService) DeploymentListWithPagination(arg0 string, arg1 scalingo.PaginationOpts) ([]*scalingo.Deployment, scalingo.PaginationMeta, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeploymentListWithPagination", arg0, arg1)
+	ret0, _ := ret[0].([]*scalingo.Deployment)
+	ret1, _ := ret[1].(scalingo.PaginationMeta)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// DeploymentListWithPagination indicates an expected call of DeploymentListWithPagination.
+func (mr *MockDeploymentsServiceMockRecorder) DeploymentListWithPagination(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeploymentListWithPagination", reflect.TypeOf((*MockDeploymentsService)(nil).DeploymentListWithPagination), arg0, arg1)
+}
+
+// DeploymentLogs mocks base method.
 func (m *MockDeploymentsService) DeploymentLogs(arg0 string) (*http.Response, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeploymentLogs", arg0)
@@ -75,13 +91,13 @@ func (m *MockDeploymentsService) DeploymentLogs(arg0 string) (*http.Response, er
 	return ret0, ret1
 }
 
-// DeploymentLogs indicates an expected call of DeploymentLogs
+// DeploymentLogs indicates an expected call of DeploymentLogs.
 func (mr *MockDeploymentsServiceMockRecorder) DeploymentLogs(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeploymentLogs", reflect.TypeOf((*MockDeploymentsService)(nil).DeploymentLogs), arg0)
 }
 
-// DeploymentStream mocks base method
+// DeploymentStream mocks base method.
 func (m *MockDeploymentsService) DeploymentStream(arg0 string) (*websocket.Conn, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeploymentStream", arg0)
@@ -90,13 +106,13 @@ func (m *MockDeploymentsService) DeploymentStream(arg0 string) (*websocket.Conn,
 	return ret0, ret1
 }
 
-// DeploymentStream indicates an expected call of DeploymentStream
+// DeploymentStream indicates an expected call of DeploymentStream.
 func (mr *MockDeploymentsServiceMockRecorder) DeploymentStream(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeploymentStream", reflect.TypeOf((*MockDeploymentsService)(nil).DeploymentStream), arg0)
 }
 
-// DeploymentsCreate mocks base method
+// DeploymentsCreate mocks base method.
 func (m *MockDeploymentsService) DeploymentsCreate(arg0 string, arg1 *scalingo.DeploymentsCreateParams) (*scalingo.Deployment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeploymentsCreate", arg0, arg1)
@@ -105,7 +121,7 @@ func (m *MockDeploymentsService) DeploymentsCreate(arg0 string, arg1 *scalingo.D
 	return ret0, ret1
 }
 
-// DeploymentsCreate indicates an expected call of DeploymentsCreate
+// DeploymentsCreate indicates an expected call of DeploymentsCreate.
 func (mr *MockDeploymentsServiceMockRecorder) DeploymentsCreate(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeploymentsCreate", reflect.TypeOf((*MockDeploymentsService)(nil).DeploymentsCreate), arg0, arg1)


### PR DESCRIPTION
Currently, the `DeploymentList` method does not support the pagination. I added a new parameter to it. If you don't want to break the API, we may add a new method with it.

- [x] Add a [changelog entry](https://changelog.scalingo.com/)
