### PR TITLE
Update LogDrains API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * feat(scm-repo-link): Add `SCMRepoLinkList` method [#241](https://github.com/Scalingo/go-scalingo/pull/241) and [#245](https://github.com/Scalingo/go-scalingo/pull/245)
 * build(deps): bump github.com/golang-jwt/jwt/v4 from 4.1.0 to 4.4.1
 * build(deps): bump github.com/stretchr/testify from 1.7.0 to 1.7.1
+* feat(log-drains): The `LogDrainsAddonList` now returns the list of log drains [#246](https://github.com/Scalingo/go-scalingo/pull/246)
+* feat(log-drains): Cleanup the LogDrain struct [#246](https://github.com/Scalingo/go-scalingo/pull/246)
 
 ## 4.15.1
 

--- a/log_drains.go
+++ b/log_drains.go
@@ -13,7 +13,7 @@ type LogDrainsService interface {
 	LogDrainAdd(app string, params LogDrainAddParams) (*LogDrainRes, error)
 	LogDrainRemove(app, URL string) error
 	LogDrainAddonRemove(app, addonID string, URL string) error
-	LogDrainsAddonList(app string, addonID string) (LogDrainsRes, error)
+	LogDrainsAddonList(app string, addonID string) ([]LogDrain, error)
 	LogDrainAddonAdd(app string, addonID string, params LogDrainAddParams) (*LogDrainRes, error)
 }
 
@@ -41,14 +41,14 @@ func (c *Client) LogDrainsList(app string) ([]LogDrain, error) {
 	return logDrainsRes.Drains, nil
 }
 
-func (c *Client) LogDrainsAddonList(app string, addonID string) (LogDrainsRes, error) {
+func (c *Client) LogDrainsAddonList(app string, addonID string) ([]LogDrain, error) {
 	var logDrainsRes LogDrainsRes
 
 	err := c.ScalingoAPI().SubresourceList("apps", app, "addons/"+addonID+"/log_drains", nil, &logDrainsRes)
 	if err != nil {
-		return logDrainsRes, errgo.Notef(err, "fail to list the log drains of the addon %s", addonID)
+		return nil, errgo.Notef(err, "fail to list the log drains of the addon %s", addonID)
 	}
-	return logDrainsRes, nil
+	return logDrainsRes.Drains, nil
 }
 
 type LogDrainAddPayload struct {

--- a/log_drains.go
+++ b/log_drains.go
@@ -20,13 +20,8 @@ type LogDrainsService interface {
 var _ LogDrainsService = (*Client)(nil)
 
 type LogDrain struct {
-	AppID       string `json:"app_id"`
-	URL         string `json:"url"`
-	Type        string `json:"type"`
-	Host        string `json:"host"`
-	Port        string `json:"port"`
-	Token       string `json:"token"`
-	DrainRegion string `json:"drain_region"`
+	AppID string `json:"app_id"`
+	URL   string `json:"url"`
 }
 
 type LogDrainRes struct {
@@ -56,6 +51,10 @@ func (c *Client) LogDrainsAddonList(app string, addonID string) (LogDrainsRes, e
 	return logDrainsRes, nil
 }
 
+type LogDrainAddPayload struct {
+	Drain LogDrainAddParams `json:"drain"`
+}
+
 type LogDrainAddParams struct {
 	Type        string `json:"type"`
 	URL         string `json:"url"`
@@ -67,15 +66,8 @@ type LogDrainAddParams struct {
 
 func (c *Client) LogDrainAdd(app string, params LogDrainAddParams) (*LogDrainRes, error) {
 	var logDrainRes LogDrainRes
-	payload := LogDrainRes{
-		Drain: LogDrain{
-			Type:        params.Type,
-			URL:         params.URL,
-			Host:        params.Host,
-			Port:        params.Port,
-			Token:       params.Token,
-			DrainRegion: params.DrainRegion,
-		},
+	payload := LogDrainAddPayload{
+		Drain: params,
 	}
 
 	err := c.ScalingoAPI().SubresourceAdd("apps", app, "log_drains", payload, &logDrainRes)
@@ -128,15 +120,8 @@ func (c *Client) LogDrainAddonRemove(app, addonID string, URL string) error {
 
 func (c *Client) LogDrainAddonAdd(app string, addonID string, params LogDrainAddParams) (*LogDrainRes, error) {
 	var logDrainRes LogDrainRes
-	payload := LogDrainRes{
-		Drain: LogDrain{
-			Type:        params.Type,
-			URL:         params.URL,
-			Host:        params.Host,
-			Port:        params.Port,
-			Token:       params.Token,
-			DrainRegion: params.DrainRegion,
-		},
+	payload := LogDrainAddPayload{
+		Drain: params,
 	}
 
 	err := c.ScalingoAPI().SubresourceAdd("apps", app, "addons/"+addonID+"/log_drains", payload, &logDrainRes)

--- a/mocks_sig.json
+++ b/mocks_sig.json
@@ -14,7 +14,7 @@
   "github.com/Scalingo/go-scalingo.DomainsService": "5b 41 a1 fb 96 6d 8b e9 2a 02 25 04 64 75 ca 23 45 ab ac da",
   "github.com/Scalingo/go-scalingo.EventsService": "61 1a ac 54 41 28 f4 7b 66 09 e1 fd 35 79 29 70 f2 a6 5a 61",
   "github.com/Scalingo/go-scalingo.KeysService": "0c 8e c5 b3 f6 66 f0 f2 77 00 69 1e a5 a5 df 25 d7 2e 70 37",
-  "github.com/Scalingo/go-scalingo.LogDrainsService": "36 37 91 25 7c 95 f0 1f af 0e a2 69 76 9d 4f d1 8e 69 a3 17",
+  "github.com/Scalingo/go-scalingo.LogDrainsService": "1f 6c b7 8e a1 b9 fd 25 ae 5d 20 2b 52 c8 fd a6 09 ef 22 89",
   "github.com/Scalingo/go-scalingo.LoginService": "cb 29 02 54 e3 97 cb f0 93 1b 71 3d b6 4e 00 e0 01 4c d8 ae",
   "github.com/Scalingo/go-scalingo.LogsArchivesService": "7b 15 9d 8b 22 0f 4e 76 f7 cd 5f 77 2b 5a 20 60 f4 9f 9f 75",
   "github.com/Scalingo/go-scalingo.LogsService": "74 62 24 af 28 88 67 16 15 a5 f7 90 42 2a 71 09 bb 19 aa a4",

--- a/scalingomock/api_mock.go
+++ b/scalingomock/api_mock.go
@@ -1078,10 +1078,10 @@ func (mr *MockAPIMockRecorder) LogDrainRemove(arg0, arg1 interface{}) *gomock.Ca
 }
 
 // LogDrainsAddonList mocks base method.
-func (m *MockAPI) LogDrainsAddonList(arg0, arg1 string) (scalingo.LogDrainsRes, error) {
+func (m *MockAPI) LogDrainsAddonList(arg0, arg1 string) ([]scalingo.LogDrain, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogDrainsAddonList", arg0, arg1)
-	ret0, _ := ret[0].(scalingo.LogDrainsRes)
+	ret0, _ := ret[0].([]scalingo.LogDrain)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/scalingomock/logdrainsservice_mock.go
+++ b/scalingomock/logdrainsservice_mock.go
@@ -11,30 +11,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockLogDrainsService is a mock of LogDrainsService interface
+// MockLogDrainsService is a mock of LogDrainsService interface.
 type MockLogDrainsService struct {
 	ctrl     *gomock.Controller
 	recorder *MockLogDrainsServiceMockRecorder
 }
 
-// MockLogDrainsServiceMockRecorder is the mock recorder for MockLogDrainsService
+// MockLogDrainsServiceMockRecorder is the mock recorder for MockLogDrainsService.
 type MockLogDrainsServiceMockRecorder struct {
 	mock *MockLogDrainsService
 }
 
-// NewMockLogDrainsService creates a new mock instance
+// NewMockLogDrainsService creates a new mock instance.
 func NewMockLogDrainsService(ctrl *gomock.Controller) *MockLogDrainsService {
 	mock := &MockLogDrainsService{ctrl: ctrl}
 	mock.recorder = &MockLogDrainsServiceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockLogDrainsService) EXPECT() *MockLogDrainsServiceMockRecorder {
 	return m.recorder
 }
 
-// LogDrainAdd mocks base method
+// LogDrainAdd mocks base method.
 func (m *MockLogDrainsService) LogDrainAdd(arg0 string, arg1 scalingo.LogDrainAddParams) (*scalingo.LogDrainRes, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogDrainAdd", arg0, arg1)
@@ -43,13 +43,13 @@ func (m *MockLogDrainsService) LogDrainAdd(arg0 string, arg1 scalingo.LogDrainAd
 	return ret0, ret1
 }
 
-// LogDrainAdd indicates an expected call of LogDrainAdd
+// LogDrainAdd indicates an expected call of LogDrainAdd.
 func (mr *MockLogDrainsServiceMockRecorder) LogDrainAdd(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogDrainAdd", reflect.TypeOf((*MockLogDrainsService)(nil).LogDrainAdd), arg0, arg1)
 }
 
-// LogDrainAddonAdd mocks base method
+// LogDrainAddonAdd mocks base method.
 func (m *MockLogDrainsService) LogDrainAddonAdd(arg0, arg1 string, arg2 scalingo.LogDrainAddParams) (*scalingo.LogDrainRes, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogDrainAddonAdd", arg0, arg1, arg2)
@@ -58,13 +58,13 @@ func (m *MockLogDrainsService) LogDrainAddonAdd(arg0, arg1 string, arg2 scalingo
 	return ret0, ret1
 }
 
-// LogDrainAddonAdd indicates an expected call of LogDrainAddonAdd
+// LogDrainAddonAdd indicates an expected call of LogDrainAddonAdd.
 func (mr *MockLogDrainsServiceMockRecorder) LogDrainAddonAdd(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogDrainAddonAdd", reflect.TypeOf((*MockLogDrainsService)(nil).LogDrainAddonAdd), arg0, arg1, arg2)
 }
 
-// LogDrainAddonRemove mocks base method
+// LogDrainAddonRemove mocks base method.
 func (m *MockLogDrainsService) LogDrainAddonRemove(arg0, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogDrainAddonRemove", arg0, arg1, arg2)
@@ -72,13 +72,13 @@ func (m *MockLogDrainsService) LogDrainAddonRemove(arg0, arg1, arg2 string) erro
 	return ret0
 }
 
-// LogDrainAddonRemove indicates an expected call of LogDrainAddonRemove
+// LogDrainAddonRemove indicates an expected call of LogDrainAddonRemove.
 func (mr *MockLogDrainsServiceMockRecorder) LogDrainAddonRemove(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogDrainAddonRemove", reflect.TypeOf((*MockLogDrainsService)(nil).LogDrainAddonRemove), arg0, arg1, arg2)
 }
 
-// LogDrainRemove mocks base method
+// LogDrainRemove mocks base method.
 func (m *MockLogDrainsService) LogDrainRemove(arg0, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogDrainRemove", arg0, arg1)
@@ -86,28 +86,28 @@ func (m *MockLogDrainsService) LogDrainRemove(arg0, arg1 string) error {
 	return ret0
 }
 
-// LogDrainRemove indicates an expected call of LogDrainRemove
+// LogDrainRemove indicates an expected call of LogDrainRemove.
 func (mr *MockLogDrainsServiceMockRecorder) LogDrainRemove(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogDrainRemove", reflect.TypeOf((*MockLogDrainsService)(nil).LogDrainRemove), arg0, arg1)
 }
 
-// LogDrainsAddonList mocks base method
-func (m *MockLogDrainsService) LogDrainsAddonList(arg0, arg1 string) (scalingo.LogDrainsRes, error) {
+// LogDrainsAddonList mocks base method.
+func (m *MockLogDrainsService) LogDrainsAddonList(arg0, arg1 string) ([]scalingo.LogDrain, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogDrainsAddonList", arg0, arg1)
-	ret0, _ := ret[0].(scalingo.LogDrainsRes)
+	ret0, _ := ret[0].([]scalingo.LogDrain)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// LogDrainsAddonList indicates an expected call of LogDrainsAddonList
+// LogDrainsAddonList indicates an expected call of LogDrainsAddonList.
 func (mr *MockLogDrainsServiceMockRecorder) LogDrainsAddonList(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogDrainsAddonList", reflect.TypeOf((*MockLogDrainsService)(nil).LogDrainsAddonList), arg0, arg1)
 }
 
-// LogDrainsList mocks base method
+// LogDrainsList mocks base method.
 func (m *MockLogDrainsService) LogDrainsList(arg0 string) ([]scalingo.LogDrain, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogDrainsList", arg0)
@@ -116,7 +116,7 @@ func (m *MockLogDrainsService) LogDrainsList(arg0 string) ([]scalingo.LogDrain, 
 	return ret0, ret1
 }
 
-// LogDrainsList indicates an expected call of LogDrainsList
+// LogDrainsList indicates an expected call of LogDrainsList.
 func (mr *MockLogDrainsServiceMockRecorder) LogDrainsList(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogDrainsList", reflect.TypeOf((*MockLogDrainsService)(nil).LogDrainsList), arg0)


### PR DESCRIPTION
- The `LogDrain` struct was used for both the return of the log drains list methods and to create a new log drain. As the return of the API only return the URL, I thought it would be simpler to only returns a struct that match that.
- the `LogDrainsAddonList` now returns the list of log drains to be consistent with other methods

- [x] Add a [changelog entry](https://changelog.scalingo.com/)
