### PR TITLE
docs(readme): fix go-scalingo import

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository is the Go client for the [Scalingo APIs](https://developers.scal
 package main
 
 import (
-	"github.com/Scalingo/go-scalingo"
+	"github.com/Scalingo/go-scalingo/v4"
 )
 
 func getClient() (*scalingo.Client, error) {


### PR DESCRIPTION
Fix how we import go-scalingo in the README to prevent the confusion reported in #247.