### PR TITLE
fix(scm_repo_link): URL field added in the SCMRepoLink structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+* fix(sc_repo_link): add missing field `URL` in the structure `SCMRepoLink` [#281](https://github.com/Scalingo/go-scalingo/pull/282)
+
 ## 5.2.0
 
 * feat(alerts): add missing fields for alerts endpoint [#276](https://github.com/Scalingo/go-scalingo/pull/276)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## To Be Released
 
-* fix(sc_repo_link): add missing field `URL` in the structure `SCMRepoLink` [#281](https://github.com/Scalingo/go-scalingo/pull/282)
+* fix(scm_repo_link): add missing field `URL` in the structure `SCMRepoLink` [#281](https://github.com/Scalingo/go-scalingo/pull/282)
 
 ## 5.2.0
 

--- a/scm_repo_link.go
+++ b/scm_repo_link.go
@@ -48,6 +48,7 @@ type SCMRepoLink struct {
 	ID                       string            `json:"id"`
 	AppID                    string            `json:"app_id"`
 	Linker                   SCMRepoLinkLinker `json:"linker"`
+	URL                      string            `json:"url"`
 	Owner                    string            `json:"owner"`
 	Repo                     string            `json:"repo"`
 	Branch                   string            `json:"branch"`


### PR DESCRIPTION
Fix #281
