### PR TITLE
release/v6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## To Be Released
 
 ## 6.2.0
+
 * feat(status code): handle too many requests exception
 
 ## 6.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## To Be Released
+
+## 6.2.0
 * feat(status code): handle too many requests exception
 
 ## 6.1.0


### PR DESCRIPTION
- release(v6.2.0): bump version to v6.2.0

- [ ] Add a [changelog entry](https://changelog.scalingo.com/)
related to https://github.com/Scalingo/documentation/issues/1937
