### PR TITLE
feat(deployments): add support for Deployment image_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To Be Released
 
+* feat(deployments): add support for Deployment `image_size`
 * feat(events): Stack changed event
 
 BREAKING CHANGE:

--- a/deployments.go
+++ b/deployments.go
@@ -49,6 +49,7 @@ type Deployment struct {
 	Registry       string           `json:"registry"`
 	Duration       int              `json:"duration"`
 	PostdeployHook string           `json:"postdeploy_hook"`
+	ImageSize      uint64           `json:"image_size"`
 	User           *User            `json:"pusher"`
 	Links          *DeploymentLinks `json:"links"`
 }


### PR DESCRIPTION
`image_size` has recently been added (https://developers.scalingo.com/deployments)

Related to https://github.com/Scalingo/cli/issues/889

- [x] Add a [changelog entry](https://changelog.scalingo.com/)