### PR TITLE
Bump v6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+## 6.3.0
+
 * feat(apps): add support for `hds_resource`
 * feat(deployments): add support for Deployment `image_size`
 * feat(events): Stack changed event

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [ ![Codeship Status for Scalingo/go-scalingo](https://app.codeship.com/projects/cf518dc0-0034-0136-d6b3-5a0245e77f67/status?branch=master)](https://app.codeship.com/projects/279805)
 
-# Go client for Scalingo API v6.1.0
+# Go client for Scalingo API v6.3.0
 
 This repository is the Go client for the [Scalingo APIs](https://developers.scalingo.com/).
 
@@ -80,11 +80,21 @@ Bump new version number in:
 Commit, tag and create a new release:
 
 ```sh
+version="6.3.0"
+
+git switch --create release/${version}
 git add CHANGELOG.md README.md version.go
-git commit -m "Bump v6.1.0"
-git tag v6.1.0
-git push origin master v6.1.0
-gh release create v6.1.0
+git commit -m "Bump v${version}"
+git push --set-upstream origin release/${version}
+gh pr create --reviewer=EtienneM --title "$(git log -1 --pretty=%B)"
+```
+
+Once the pull request merged, you can tag the new release.
+
+```sh
+git tag v${version}
+git push origin master v${version}
+gh release create v${version}
 ```
 
 The title of the release should be the version number and the text of the

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package scalingo
 
-var Version = "6.1.0"
+var Version = "6.3.0"


### PR DESCRIPTION
* feat(apps): add support for `hds_resource`
* feat(deployments): add support for Deployment `image_size`
* feat(events): Stack changed event

BREAKING CHANGE:

* Remove the `GithubLinkService` in favor of `SCMRepoLinkService`
