### PR TITLE
feat(backup): add `StartedAt` and `Method` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## To Be Released
 
 * feat(stacks): add support for Deployment `stack_base_image`
+* feat(backup): add `StartedAt` and `Method` fields
 
 ## 6.3.0
 

--- a/backups.go
+++ b/backups.go
@@ -26,14 +26,22 @@ const (
 	BackupStatusError     BackupStatus = "error"
 )
 
+type BackupMethod string
+
+const (
+	BackupMethodPeriodic BackupMethod = "periodic"
+	BackupMethodManual   BackupMethod = "manual"
+)
+
 type Backup struct {
 	ID         string       `json:"id"`
 	CreatedAt  time.Time    `json:"created_at"`
+	StartedAt  time.Time    `json:"started_at"`
 	Name       string       `json:"name"`
 	Size       uint64       `json:"size"`
 	Status     BackupStatus `json:"status"`
 	DatabaseID string       `json:"database_id"`
-	Direct     bool         `json:"direct"`
+	Method     BackupMethod `json:"method"`
 }
 
 type BackupsRes struct {


### PR DESCRIPTION
This is an attempt at triggering the CI.
Replaces #310 

- [x] Add a [changelog entry](https://changelog.scalingo.com/)