### PR TITLE
Bump v6.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+## 6.4.0
+
 * feat(one-off): allow attached one-off to be run asynchronously
 * feat(stacks): add support for Deployment `stack_base_image`
 * feat(backup): add `StartedAt` and `Method` fields

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [ ![Codeship Status for Scalingo/go-scalingo](https://app.codeship.com/projects/cf518dc0-0034-0136-d6b3-5a0245e77f67/status?branch=master)](https://app.codeship.com/projects/279805)
 
-# Go client for Scalingo API v6.3.0
+# Go client for Scalingo API v6.4.0
 
 This repository is the Go client for the [Scalingo APIs](https://developers.scalingo.com/).
 
@@ -80,7 +80,7 @@ Bump new version number in:
 Commit, tag and create a new release:
 
 ```sh
-version="6.3.0"
+version="6.4.0"
 
 git switch --create release/${version}
 git add CHANGELOG.md README.md version.go

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package scalingo
 
-var Version = "6.3.0"
+var Version = "6.4.0"


### PR DESCRIPTION
- [x] Add a [changelog entry](https://changelog.scalingo.com/) link to https://github.com/Scalingo/documentation/pull/2026
