### PR TITLE
refactor(users): reduce nesting

### DIFF
--- a/stacks_test.go
+++ b/stacks_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Scalingo/go-scalingo/v6/http/httpmock"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/Scalingo/go-scalingo/v6/http/httpmock"
 )
 
 func TestStackIsDeprecated(t *testing.T) {

--- a/users.go
+++ b/users.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 
 	"gopkg.in/errgo.v1"
-	
+
 	"github.com/Scalingo/go-scalingo/v6/http"
 )
 

--- a/users.go
+++ b/users.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 
 	"gopkg.in/errgo.v1"
-
+	
 	"github.com/Scalingo/go-scalingo/v6/http"
 )
 
@@ -57,33 +57,31 @@ type UpdateUserResponse struct {
 }
 
 func (c *Client) UpdateUser(ctx context.Context, params UpdateUserParams) (*User, error) {
-	var user *User
-
-	if params.Password != "" || params.Email != "" {
-		req := &http.APIRequest{
-			Method:   "PATCH",
-			Endpoint: "/account/profile",
-			Params: map[string]interface{}{
-				"user": params,
-			},
-			Expected: http.Statuses{200},
-		}
-		res, err := c.AuthAPI().Do(ctx, req)
-		if err != nil {
-			return nil, errgo.Notef(err, "fail to execute the query to update the user")
-		}
-		defer res.Body.Close()
-
-		var u UpdateUserResponse
-		err = json.NewDecoder(res.Body).Decode(&u)
-		if err != nil {
-			return nil, errgo.Notef(err, "fail to decode response of the query to update the user")
-		}
-
-		user = u.User
+	if params.Password == "" && params.Email == "" {
+		return nil, nil
 	}
 
-	return user, nil
+	req := &http.APIRequest{
+		Method:   "PATCH",
+		Endpoint: "/account/profile",
+		Params: map[string]interface{}{
+			"user": params,
+		},
+		Expected: http.Statuses{200},
+	}
+	res, err := c.AuthAPI().Do(ctx, req)
+	if err != nil {
+		return nil, errgo.Notef(err, "fail to execute the query to update the user")
+	}
+	defer res.Body.Close()
+
+	var u UpdateUserResponse
+	err = json.NewDecoder(res.Body).Decode(&u)
+	if err != nil {
+		return nil, errgo.Notef(err, "fail to decode response of the query to update the user")
+	}
+
+	return u.User, nil
 }
 
 func (c *Client) UserStopFreeTrial(ctx context.Context) error {


### PR DESCRIPTION
- [ ] Add a [changelog entry](https://changelog.scalingo.com/)

Nit pull request.
I see an opportunity to reduce a small nesting piece of code. It's not a big deal but i assume it can save some memory usage by removing `var user *User`.

Reference:
https://github.com/uber-go/guide/blob/master/style.md#reduce-nesting