### PR TITLE
Bump v6.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+## 6.7.1
+
 * style(readme): update api version
 
 ## 6.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+* style(readme): update api version
+
 ## 6.7.0
 
 * feat(maintenance): add maintenance windows

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [ ![Codeship Status for Scalingo/go-scalingo](https://app.codeship.com/projects/cf518dc0-0034-0136-d6b3-5a0245e77f67/status?branch=master)](https://app.codeship.com/projects/279805)
 
-# Go client for Scalingo API v6.5.0
+# Go client for Scalingo API v6.7.0
 
 This repository is the Go client for the [Scalingo APIs](https://developers.scalingo.com/).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [ ![Codeship Status for Scalingo/go-scalingo](https://app.codeship.com/projects/cf518dc0-0034-0136-d6b3-5a0245e77f67/status?branch=master)](https://app.codeship.com/projects/279805)
 
-# Go client for Scalingo API v6.7.0
+# Go client for Scalingo API v6.7.1
 
 This repository is the Go client for the [Scalingo APIs](https://developers.scalingo.com/).
 
@@ -80,7 +80,7 @@ Bump new version number in:
 Commit, tag and create a new release:
 
 ```sh
-version="6.7.0"
+version="6.7.1"
 
 git switch --create release/${version}
 git add CHANGELOG.md README.md version.go

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package scalingo
 
-var Version = "6.7.0"
+var Version = "6.7.1"


### PR DESCRIPTION
- style(readme): update api version
- Bump v6.7.1

- [ ] Add a [changelog entry](https://changelog.scalingo.com/)
