### PR TITLE
fix(wording): ambiguous event name when restarting containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## To Be Released
 
 * refactor(tokens): deprecate `ErrOTPRequired` and `IsOTPRequired`
+* fix(wording): disambiguate event name when restarting containers
 
 ## 6.7.2
 

--- a/events_app.go
+++ b/events_app.go
@@ -93,9 +93,9 @@ type EventRestartType struct {
 
 func (ev *EventRestartType) String() string {
 	if len(ev.TypeData.Scope) != 0 {
-		return fmt.Sprintf("containers %v have been restarted", ev.TypeData.Scope)
+		return fmt.Sprintf("containers %v began to restart", ev.TypeData.Scope)
 	}
-	return "containers have been restarted"
+	return "containers began to restart"
 }
 
 func (ev *EventRestartType) Who() string {

--- a/events_structs_test.go
+++ b/events_structs_test.go
@@ -22,7 +22,7 @@ var eventsSpecializeCases = map[string]struct {
 			RawTypeData: json.RawMessage([]byte(`{"scope": ["web"]}`)),
 		},
 		DetailedEventName:   "*scalingo.EventRestartType",
-		DetailedEventString: "containers [web] have been restarted",
+		DetailedEventString: "containers [web] began to restart",
 	},
 	"test edit app event without with null force_https": {
 		Event: &Event{


### PR DESCRIPTION
no need for changelog entry, open to suggestions on the sentence

thought about "containers are restarting" but time used isn't past

fixes #324