### PR TITLE
refactor(tokens): deprecate `ErrOTPRequired` and `IsOTPRequired`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+* refactor(tokens): deprecate `ErrOTPRequired` and `IsOTPRequired`
+
 ## 6.7.2
 
 * fix(maintenance): change listing pagination meta to standard pagination meta

--- a/tokens.go
+++ b/tokens.go
@@ -3,7 +3,6 @@ package scalingo
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"strconv"
 	"time"
 
@@ -20,19 +19,15 @@ type TokensService interface {
 }
 
 var _ TokensService = (*Client)(nil)
-var ErrOTPRequired = errors.New("OTP Required")
+
+// Deprecated: use http.ErrOTPRequired instead of this wrapper.
+var ErrOTPRequired = http.ErrOTPRequired
 
 // IsOTPRequired tests if the authentication backend return an OTP Required error
+//
+// Deprecated: use http.IsOTPRequired instead of this wrapper.
 func IsOTPRequired(err error) bool {
-	rerr, ok := err.(*http.RequestFailedError)
-	if !ok {
-		return false
-	}
-
-	if rerr.Message == "OTP Required" {
-		return true
-	}
-	return false
+	return http.IsOTPRequired(err)
 }
 
 type Token struct {
@@ -117,8 +112,8 @@ func (c *Client) TokenCreateWithLogin(ctx context.Context, params TokenCreatePar
 
 	resp, err := c.AuthAPI().Do(ctx, req)
 	if err != nil {
-		if IsOTPRequired(err) {
-			return Token{}, ErrOTPRequired
+		if http.IsOTPRequired(err) {
+			return Token{}, http.ErrOTPRequired
 		}
 		return Token{}, errgo.Notef(err, "request failed")
 	}


### PR DESCRIPTION
This is only used in the CLI in our codebase:

https://github.com/Scalingo/cli/blob/9e342bdf9d3c04a80a14455c6a4786ed19142b74/config/auth.go#L260

I'll create a PR to update it there.

I kept the error declaration in the `http` package as it seems more relevant to have it in this package. It is a nicer Go error for a HTTP error returned by the API.

Fix #360

I don't think it is worth a changelog entry in the global Scalingo changelog
- [ ] ~Add a [changelog entry](https://changelog.scalingo.com/)~