### PR TITLE
fix(events): `link_scm` data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+fix(events): link_scm data types
+
 ## 6.7.4
 
 * feat(database): add user management

--- a/events_structs.go
+++ b/events_structs.go
@@ -253,13 +253,13 @@ type EventLinkSCMTypeData struct {
 	LinkerUsername           string `json:"linker_username"`
 	Source                   string `json:"source"`
 	Branch                   string `json:"branch"`
-	AutoDeploy               string `json:"auto_deploy"`
-	AutoDeployReviewApps     string `json:"auto_deploy_review_apps"`
-	DeleteOnClose            string `json:"delete_on_close"`
-	DeleteStale              string `json:"delete_stale"`
-	HoursBeforeDeleteOnClose string `json:"hours_before_delete_on_close"`
-	HoursBeforeDeleteStale   string `json:"hours_before_delete_stale"`
-	CreationFromForksAllowed string `json:"creation_from_forks_allowed"`
+	AutoDeploy               bool   `json:"auto_deploy"`
+	AutoDeployReviewApps     bool   `json:"auto_deploy_review_apps"`
+	DeleteOnClose            bool   `json:"delete_on_close"`
+	DeleteStale              bool   `json:"delete_stale"`
+	HoursBeforeDeleteOnClose int    `json:"hours_before_delete_on_close"`
+	HoursBeforeDeleteStale   int    `json:"hours_before_delete_stale"`
+	CreationFromForksAllowed bool   `json:"creation_from_forks_allowed"`
 }
 
 type EventUpdateSCMType struct {


### PR DESCRIPTION
Tested in the CLI PR https://github.com/Scalingo/cli/pull/1023

Bug introduced here: https://github.com/Scalingo/api/commit/f3cb678bdfc10084ead9d609f2dc4c977ec75c29#diff-f82734ec66b682822460f5f57892cb41ece508296c00270b648a4d2e442df75bR7

Related to https://github.com/Scalingo/cli/issues/1022

- [x] Add a [changelog entry](https://changelog.scalingo.com/)