### PR TITLE
fix(one-off): remove async field from the run command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+* fix(one-off): remove async field from the run command ([PR#390](https://github.com/Scalingo/go-scalingo/pull/390))
+
 ## 7.0.1
 
 * feat(apps):  add the `private_network_ids` field to the model

--- a/run.go
+++ b/run.go
@@ -21,7 +21,6 @@ type RunOpts struct {
 	Env        map[string]string
 	Size       string
 	Detached   bool
-	Async      bool
 	HasUploads bool
 }
 
@@ -40,7 +39,6 @@ func (c *Client) Run(ctx context.Context, opts RunOpts) (*RunRes, error) {
 			"env":         opts.Env,
 			"size":        opts.Size,
 			"detached":    opts.Detached,
-			"async":       opts.Async,
 			"has_uploads": opts.HasUploads,
 		},
 	}


### PR DESCRIPTION
- [x] Add a [changelog entry](https://changelog.scalingo.com/)