### PR TITLE
[STORY-2252] Add support for updating a collaborator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+* feat(collaborators): add update collaborator method
+
 ## 8.2.0
 
 * feat(projects): add edit project event

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ documentation](https://developers.scalingo.com/index#errors).
 
 ### Release a New Version
 
+#### Create the new release
+
 Bump new version number in:
 
 - `CHANGELOG.md`
@@ -99,3 +101,8 @@ gh release create v${version}
 
 The title of the release should be the version number and the text of the
 release is the same as the changelog.
+
+#### Document the new release on the documentation
+
+When a new version is released, it must be documented on the general [changelog](https://doc.scalingo.com/changelog).
+In order to do that, a new file must be created in this [folder](https://github.com/Scalingo/documentation/tree/master/src/changelog/sdk/_posts).

--- a/collaborators.go
+++ b/collaborators.go
@@ -17,7 +17,8 @@ const (
 type CollaboratorsService interface {
 	CollaboratorsList(ctx context.Context, app string) ([]Collaborator, error)
 	CollaboratorAdd(ctx context.Context, app string, params CollaboratorAddParams) (Collaborator, error)
-	CollaboratorRemove(ctx context.Context, app string, id string) error
+	CollaboratorRemove(ctx context.Context, app, collaboratorID string) error
+	CollaboratorUpdate(ctx context.Context, app, collaboratorID string, params CollaboratorUpdateParams) (Collaborator, error)
 }
 
 var _ CollaboratorsService = (*Client)(nil)
@@ -49,6 +50,14 @@ type CollaboratorAddParamsPayload struct {
 	Collaborator CollaboratorAddParams `json:"collaborator"`
 }
 
+type CollaboratorUpdateParams struct {
+	IsLimited bool `json:"is_limited"`
+}
+
+type CollaboratorUpdateParamsPayload struct {
+	Collaborator CollaboratorUpdateParams `json:"collaborator"`
+}
+
 func (c *Client) CollaboratorsList(ctx context.Context, app string) ([]Collaborator, error) {
 	var collaboratorsRes CollaboratorsRes
 	err := c.ScalingoAPI().SubresourceList(ctx, "apps", app, "collaborators", nil, &collaboratorsRes)
@@ -67,6 +76,15 @@ func (c *Client) CollaboratorAdd(ctx context.Context, app string, params Collabo
 	return collaboratorRes.Collaborator, nil
 }
 
-func (c *Client) CollaboratorRemove(ctx context.Context, app string, id string) error {
-	return c.ScalingoAPI().SubresourceDelete(ctx, "apps", app, "collaborators", id)
+func (c *Client) CollaboratorRemove(ctx context.Context, app, collaboratorID string) error {
+	return c.ScalingoAPI().SubresourceDelete(ctx, "apps", app, "collaborators", collaboratorID)
+}
+
+func (c *Client) CollaboratorUpdate(ctx context.Context, app, collaboratorID string, params CollaboratorUpdateParams) (Collaborator, error) {
+	var collaboratorRes CollaboratorRes
+	err := c.ScalingoAPI().SubresourceUpdate(ctx, "apps", app, "collaborators", collaboratorID, CollaboratorUpdateParamsPayload{params}, &collaboratorRes)
+	if err != nil {
+		return Collaborator{}, errgo.Mask(err)
+	}
+	return collaboratorRes.Collaborator, nil
 }

--- a/collaborators.go
+++ b/collaborators.go
@@ -3,7 +3,7 @@ package scalingo
 import (
 	"context"
 
-	"gopkg.in/errgo.v1"
+	"github.com/Scalingo/go-utils/errors/v2"
 )
 
 type CollaboratorStatus string
@@ -62,7 +62,7 @@ func (c *Client) CollaboratorsList(ctx context.Context, app string) ([]Collabora
 	var collaboratorsRes CollaboratorsRes
 	err := c.ScalingoAPI().SubresourceList(ctx, "apps", app, "collaborators", nil, &collaboratorsRes)
 	if err != nil {
-		return nil, errgo.Mask(err)
+		return nil, errors.Wrap(ctx, err, "list collaborators")
 	}
 	return collaboratorsRes.Collaborators, nil
 }
@@ -71,20 +71,24 @@ func (c *Client) CollaboratorAdd(ctx context.Context, app string, params Collabo
 	var collaboratorRes CollaboratorRes
 	err := c.ScalingoAPI().SubresourceAdd(ctx, "apps", app, "collaborators", CollaboratorAddParamsPayload{params}, &collaboratorRes)
 	if err != nil {
-		return Collaborator{}, errgo.Mask(err)
+		return Collaborator{}, errors.Wrap(ctx, err, "add collaborator")
 	}
 	return collaboratorRes.Collaborator, nil
 }
 
 func (c *Client) CollaboratorRemove(ctx context.Context, app, collaboratorID string) error {
-	return c.ScalingoAPI().SubresourceDelete(ctx, "apps", app, "collaborators", collaboratorID)
+	err := c.ScalingoAPI().SubresourceDelete(ctx, "apps", app, "collaborators", collaboratorID)
+	if err != nil {
+		return errors.Wrap(ctx, err, "remove collaborator")
+	}
+	return nil
 }
 
 func (c *Client) CollaboratorUpdate(ctx context.Context, app, collaboratorID string, params CollaboratorUpdateParams) (Collaborator, error) {
 	var collaboratorRes CollaboratorRes
 	err := c.ScalingoAPI().SubresourceUpdate(ctx, "apps", app, "collaborators", collaboratorID, CollaboratorUpdateParamsPayload{params}, &collaboratorRes)
 	if err != nil {
-		return Collaborator{}, errgo.Mask(err)
+		return Collaborator{}, errors.Wrap(ctx, err, "update collaborator")
 	}
 	return collaboratorRes.Collaborator, nil
 }

--- a/mocks_sig.json
+++ b/mocks_sig.json
@@ -6,7 +6,7 @@
   "github.com/Scalingo/go-scalingo.AppsService": "bd ac 01 ef a1 ae 45 1e b8 66 b7 d1 ec e3 71 31 c2 62 01 5f",
   "github.com/Scalingo/go-scalingo.AutoscalersService": "9f cf 1b 7a dc 9d e3 d3 62 89 41 0f d4 30 83 28 7b 40 f1 72",
   "github.com/Scalingo/go-scalingo.BackupsService": "66 59 74 49 68 65 69 e4 b0 97 8e a2 45 e6 ff fc 71 85 06 16",
-  "github.com/Scalingo/go-scalingo.CollaboratorsService": "1b 74 d7 c0 4c da dc 56 22 89 dc 7a 9e ba 77 33 e9 2a 2b 68",
+  "github.com/Scalingo/go-scalingo.CollaboratorsService": "c9 3a 93 de 00 2d e8 87 9c cc bd 3f f0 0e a1 48 78 a4 d7 3a",
   "github.com/Scalingo/go-scalingo.ContainerSizesService": "e2 db 25 a1 01 52 dc e9 6f 7b f4 59 68 95 86 b9 5e 39 8a 61",
   "github.com/Scalingo/go-scalingo.ContainersService": "ef 14 ae 81 c9 b4 6a 13 48 e8 bf 44 7d b5 b2 a6 4d e5 02 11",
   "github.com/Scalingo/go-scalingo.CronTasksService": "9b d9 a3 ca 9f 9a f7 73 cb b1 aa 80 df 90 21 ff 14 92 b4 4d",

--- a/scalingomock/api_mock.go
+++ b/scalingomock/api_mock.go
@@ -617,6 +617,21 @@ func (mr *MockAPIMockRecorder) CollaboratorRemove(arg0, arg1, arg2 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CollaboratorRemove", reflect.TypeOf((*MockAPI)(nil).CollaboratorRemove), arg0, arg1, arg2)
 }
 
+// CollaboratorUpdate mocks base method.
+func (m *MockAPI) CollaboratorUpdate(arg0 context.Context, arg1, arg2 string, arg3 scalingo.CollaboratorUpdateParams) (scalingo.Collaborator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CollaboratorUpdate", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(scalingo.Collaborator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CollaboratorUpdate indicates an expected call of CollaboratorUpdate.
+func (mr *MockAPIMockRecorder) CollaboratorUpdate(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CollaboratorUpdate", reflect.TypeOf((*MockAPI)(nil).CollaboratorUpdate), arg0, arg1, arg2, arg3)
+}
+
 // CollaboratorsList mocks base method.
 func (m *MockAPI) CollaboratorsList(arg0 context.Context, arg1 string) ([]scalingo.Collaborator, error) {
 	m.ctrl.T.Helper()

--- a/scalingomock/collaboratorsservice_mock.go
+++ b/scalingomock/collaboratorsservice_mock.go
@@ -36,7 +36,7 @@ func (m *MockCollaboratorsService) EXPECT() *MockCollaboratorsServiceMockRecorde
 }
 
 // CollaboratorAdd mocks base method.
-func (m *MockCollaboratorsService) CollaboratorAdd(arg0 context.Context, arg1, arg2 string) (scalingo.Collaborator, error) {
+func (m *MockCollaboratorsService) CollaboratorAdd(arg0 context.Context, arg1 string, arg2 scalingo.CollaboratorAddParams) (scalingo.Collaborator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CollaboratorAdd", arg0, arg1, arg2)
 	ret0, _ := ret[0].(scalingo.Collaborator)
@@ -62,6 +62,21 @@ func (m *MockCollaboratorsService) CollaboratorRemove(arg0 context.Context, arg1
 func (mr *MockCollaboratorsServiceMockRecorder) CollaboratorRemove(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CollaboratorRemove", reflect.TypeOf((*MockCollaboratorsService)(nil).CollaboratorRemove), arg0, arg1, arg2)
+}
+
+// CollaboratorUpdate mocks base method.
+func (m *MockCollaboratorsService) CollaboratorUpdate(arg0 context.Context, arg1, arg2 string, arg3 scalingo.CollaboratorUpdateParams) (scalingo.Collaborator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CollaboratorUpdate", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(scalingo.Collaborator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CollaboratorUpdate indicates an expected call of CollaboratorUpdate.
+func (mr *MockCollaboratorsServiceMockRecorder) CollaboratorUpdate(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CollaboratorUpdate", reflect.TypeOf((*MockCollaboratorsService)(nil).CollaboratorUpdate), arg0, arg1, arg2, arg3)
 }
 
 // CollaboratorsList mocks base method.


### PR DESCRIPTION
This PR adds a new method to update a collaborator. Right now only the `is_limited` attribute is supported.

- [x] Mocks are generated
- [x] Add a [changelog entry](https://changelog.scalingo.com/)
  - Done [here](https://github.com/Scalingo/documentation/pull/3252)
- [X] QA was done thanks to [this](https://github.com/Scalingo/cli/pull/1125) PR
