### PR TITLE
[STORY-2323] Add "projects" management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+* feat(projects): add types and methods to handle projects
+
 ## 8.3.0
 
 * feat(collaborators): add update collaborator method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## To Be Released
 
 * feat(projects): add types and methods to handle projects
+* task: handle 409 return calls (Conflict)
 
 ## 8.3.0
 

--- a/apps.go
+++ b/apps.go
@@ -80,6 +80,7 @@ type AppsCreateOpts struct {
 	Name      string `json:"name"`
 	ParentApp string `json:"parent_id,omitempty"`
 	StackID   string `json:"stack_id,omitempty"`
+	ProjectID string `json:"project_id,omitempty"`
 }
 
 type AppResponse struct {

--- a/apps.go
+++ b/apps.go
@@ -2,6 +2,7 @@ package scalingo
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -124,6 +125,11 @@ type App struct {
 type appProject struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
+}
+
+// ProjectSlug returns a unique identifier for a project, under the format <ownerUsername>/<projectName>.
+func (app App) ProjectSlug() string {
+	return fmt.Sprintf("%s/%s", app.Owner.Username, app.Project.Name)
 }
 
 func (app App) String() string {

--- a/apps.go
+++ b/apps.go
@@ -116,6 +116,14 @@ type App struct {
 	Limits             map[string]interface{} `json:"limits"`
 	HDSResource        bool                   `json:"hds_resource"`
 	PrivateNetworksIDs []string               `json:"private_networks_ids"`
+	Project            appProject             `json:"project,omitempty"`
+}
+
+// appProject is a partial copy of the type `Project` in `projects.go`
+// This is required because the API doesn't fill the entire object in the scope of applications.
+type appProject struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 func (app App) String() string {

--- a/projects.go
+++ b/projects.go
@@ -1,0 +1,104 @@
+package scalingo
+
+import (
+	"context"
+	"time"
+
+	"github.com/Scalingo/go-utils/errors/v2"
+)
+
+const projectResource = "projects"
+
+type ProjectsService interface {
+	ProjectsList(ctx context.Context) ([]Project, error)
+	ProjectAdd(ctx context.Context, params ProjectAddParams) (Project, error)
+	ProjectUpdate(ctx context.Context, projectID string, params ProjectUpdateParams) (Project, error)
+	ProjectGet(ctx context.Context, projectID string) (Project, error)
+	ProjectDelete(ctx context.Context, projectID string) error
+}
+
+var _ ProjectsService = (*Client)(nil)
+
+type Project struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Default   bool      `json:"default"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	Owner     Owner     `json:"owner"`
+}
+
+type ProjectsRes struct {
+	Projects []Project `json:"projects"`
+}
+
+type ProjectRes struct {
+	Project Project `json:"project"`
+}
+
+type ProjectAddParams struct {
+	Name    string `json:"name"`
+	Default bool   `json:"default"`
+}
+
+type projectAddParamsPayload struct {
+	Project ProjectAddParams `json:"project"`
+}
+
+type ProjectUpdateParams struct {
+	Name    *string `json:"name"`
+	Default *bool   `json:"default"`
+}
+
+type projectUpdateParamsPayload struct {
+	Project ProjectUpdateParams `json:"project"`
+}
+
+func (c *Client) ProjectsList(ctx context.Context) ([]Project, error) {
+	var projectsRes ProjectsRes
+	err := c.ScalingoAPI().ResourceList(ctx, projectResource, nil, &projectsRes)
+	if err != nil {
+		return nil, errors.Wrap(ctx, err, "list projects")
+	}
+
+	return projectsRes.Projects, nil
+}
+
+func (c *Client) ProjectAdd(ctx context.Context, params ProjectAddParams) (Project, error) {
+	var projectRes ProjectRes
+	err := c.ScalingoAPI().ResourceAdd(ctx, projectResource, projectAddParamsPayload{Project: params}, &projectRes)
+	if err != nil {
+		return Project{}, errors.Wrap(ctx, err, "add project")
+	}
+
+	return projectRes.Project, nil
+}
+
+func (c *Client) ProjectUpdate(ctx context.Context, projectID string, params ProjectUpdateParams) (Project, error) {
+	var projectRes ProjectRes
+	err := c.ScalingoAPI().ResourceUpdate(ctx, projectResource, projectID, projectUpdateParamsPayload{Project: params}, &projectRes)
+	if err != nil {
+		return Project{}, errors.Wrap(ctx, err, "update project")
+	}
+
+	return projectRes.Project, nil
+}
+
+func (c *Client) ProjectGet(ctx context.Context, projectID string) (Project, error) {
+	var projectRes ProjectRes
+	err := c.ScalingoAPI().ResourceGet(ctx, projectResource, projectID, nil, &projectRes)
+	if err != nil {
+		return Project{}, errors.Wrap(ctx, err, "get project")
+	}
+
+	return projectRes.Project, nil
+}
+
+func (c *Client) ProjectDelete(ctx context.Context, projectID string) error {
+	err := c.ScalingoAPI().ResourceDelete(ctx, projectResource, projectID)
+	if err != nil {
+		return errors.Wrap(ctx, err, "delete project")
+	}
+
+	return nil
+}

--- a/projects.go
+++ b/projects.go
@@ -45,9 +45,11 @@ type projectAddParamsPayload struct {
 	Project ProjectAddParams `json:"project"`
 }
 
+// ProjectUpdateParams holds the attribute to update a project.
+// The omitempty directive is required because the API doesn't handle eg `"default": null` so the field cannot be set.
 type ProjectUpdateParams struct {
-	Name    *string `json:"name"`
-	Default *bool   `json:"default"`
+	Name    *string `json:"name,omitempty"`
+	Default *bool   `json:"default,omitempty"`
 }
 
 type projectUpdateParamsPayload struct {


### PR DESCRIPTION
This PR adds the support for all the `projects` endpoint from the [documentation](https://developers.scalingo.com/projects).
This will be QAed with the CLI, and will probably be merged in ~last~ first one all PRs are ready and reviewed.
EDIT: QA went fine with the two PRs using that change.

- [X] Add a [changelog entry](https://changelog.scalingo.com/)
