### PR TITLE
Add method on application to set the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## To Be Released
 
+* feat(applications): create a new method to set the project
+
 ## 8.5.0
 
-- feat(client): create a new client for preview features
-- feat(databases): extend the preview client with types and methods to handle databases next generation
+* feat(client): create a new client for preview features
+* feat(databases): extend the preview client with types and methods to handle databases next generation
 
 ## 8.4.1
 

--- a/apps.go
+++ b/apps.go
@@ -335,6 +335,12 @@ func (c *Client) AppsStickySession(ctx context.Context, name string, enable bool
 	})
 }
 
+func (c *Client) AppsSetProject(ctx context.Context, name string, projectID string) (*App, error) {
+	return c.appsUpdate(ctx, name, map[string]interface{}{
+		"project_id": projectID,
+	})
+}
+
 func (c *Client) appsUpdate(ctx context.Context, name string, params map[string]interface{}) (*App, error) {
 	var appRes *AppResponse
 	req := &httpclient.APIRequest{


### PR DESCRIPTION
As there is no generic application update, I followed the same pattern as existing so I added a new method.

- [X] Add a [changelog entry](https://changelog.scalingo.com/)
