### PR TITLE
feat(EventRestart): add `Reason` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+* feat(EventRestart): add `Reason` field
+
 ## 11.0.1
 
 * chore(deps): bump `golang.org/x/text` from `0.34.0` to `0.35.0` ([#494](https://github.com/Scalingo/go-scalingo/pull/494))

--- a/events_app.go
+++ b/events_app.go
@@ -106,8 +106,9 @@ func (ev *EventTransferAppType) String() string {
 }
 
 type EventRestartTypeData struct {
-	Scope     []string `json:"scope"`
-	AddonName string   `json:"addon_name"`
+	Scope     []string               `json:"scope"`
+	AddonName string                 `json:"addon_name"`
+	Reason    ContainerRestartReason `json:"reason"`
 }
 
 type EventRestartType struct {
@@ -116,11 +117,37 @@ type EventRestartType struct {
 	TypeData EventRestartTypeData `json:"type_data"`
 }
 
+// ContainerRestartReason identifies the logical origin of a restart request
+type ContainerRestartReason string
+
+const (
+	ContainerRestartReasonUserRestart          ContainerRestartReason = "user_restart"
+	ContainerRestartReasonUnexpectedFailure    ContainerRestartReason = "unexpected_failure"
+	ContainerRestartReasonRebalancingOperation ContainerRestartReason = "rebalancing_operation"
+	ContainerRestartReasonSecurityMaintenance  ContainerRestartReason = "security_maintenance"
+)
+
 func (ev *EventRestartType) String() string {
+	message := "containers began to restart"
 	if len(ev.TypeData.Scope) != 0 {
-		return fmt.Sprintf("containers %v began to restart", ev.TypeData.Scope)
+		message = fmt.Sprintf("containers %v began to restart", ev.TypeData.Scope)
 	}
-	return "containers began to restart"
+	if ev.TypeData.Reason != "" {
+		reason := ev.TypeData.Reason
+		switch ev.TypeData.Reason {
+		case ContainerRestartReasonUserRestart:
+			reason = "user restart"
+		case ContainerRestartReasonUnexpectedFailure:
+			reason = "unexpected failure"
+		case ContainerRestartReasonRebalancingOperation:
+			reason = "infrastructure rebalancing operation"
+		case ContainerRestartReasonSecurityMaintenance:
+			reason = "scheduled security maintenance"
+		}
+
+		message = fmt.Sprintf("%s (reason: %s)", message, reason)
+	}
+	return message
 }
 
 func (ev *EventRestartType) Who() string {


### PR DESCRIPTION
When used in the CLI, it outputs:

```
 blscalingo --app biniou timeline
* Mon Apr 13 2026 11:40:00 - Restart    - containers [web-2] began to restart (reason: infrastructure rebalancing operation) <scalingo-platform (deploy@scalingo.com)>
* Mon Apr 13 2026 11:20:00 - Restart    - containers [web-2] began to restart (reason: infrastructure rebalancing operation) <scalingo-platform (deploy@scalingo.com)>
* Mon Apr 13 2026 11:00:00 - Restart    - containers [web-2] began to restart (reason: infrastructure rebalancing operation) <scalingo-platform (deploy@scalingo.com)>
* Mon Apr 13 2026 09:02:36 - Restart    - containers began to restart (reason: user restart) <admin-auth (admin-auth@scalingo.com)>
```

- [x] Add a [changelog entry](https://changelog.scalingo.com/)