### PR TITLE
fix(run): add JSON tag for `OperationURL`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+* fix(run): add JSON tag for `OperationURL`
+
 ## 11.0.2
 
 * feat(EventRestart): add `Reason` field

--- a/run.go
+++ b/run.go
@@ -26,7 +26,7 @@ type RunOpts struct {
 type RunRes struct {
 	Container    *Container `json:"container"`
 	AttachURL    string     `json:"attach_url"`
-	OperationURL string     `json:"-"`
+	OperationURL string     `json:"operation_url"`
 }
 
 func (c *Client) Run(ctx context.Context, opts RunOpts) (*RunRes, error) {


### PR DESCRIPTION
What bothers me is that I fail to understand how it used to work... It apparently broke only with the latest CLI release. But the JSON tag has been set that way for the last 3 years. How is it possible that it worked in the past 3 years?! 
But looking at the history of this file and the CLI file really puzzles me

This is tested in https://github.com/Scalingo/cli/pull/1215

Related to https://github.com/Scalingo/cli/issues/1214

- [x] Add a [changelog entry](https://changelog.scalingo.com/)