### PR TITLE
feat(databases): Add new method to restore PITR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+* feat(databases): Add new method to restore PITR
+
 ## 11.1.1
 
 * feat(events): add database continuous backup events

--- a/databases.go
+++ b/databases.go
@@ -20,6 +20,7 @@ type DatabasesService interface {
 	DatabaseUpdateMaintenanceWindow(ctx context.Context, app, addonID string, params MaintenanceWindowParams) (Database, error)
 	DatabaseListMaintenance(ctx context.Context, app, addonID string, paginationReq pagination.Request) ([]*Maintenance, pagination.Meta, error)
 	DatabaseShowMaintenance(ctx context.Context, app, addonID, maintenanceID string) (Maintenance, error)
+	DatabasePITRRestore(ctx context.Context, app, addonID string, restoreTime time.Time) (string, error)
 }
 
 // DatabaseStatus is a string representing the status of a database deployment
@@ -333,4 +334,31 @@ func (c *Client) DatabaseUserResetPassword(ctx context.Context, app, addonID, us
 	}
 
 	return res.DatabaseUser, nil
+}
+
+type databasePITRRestorePayload struct {
+	RestoreTime time.Time `json:"restore_time"`
+}
+
+// databasePITRRestoreRes is the response body of database PITR restore.
+type databasePITRRestoreRes struct {
+	OperationID string `json:"operation_id"`
+}
+
+// DatabasePITRRestore asks for a PiTR restore of the given addon/database.
+// It returns the linked operation ID.
+func (c *Client) DatabasePITRRestore(ctx context.Context, app, addonID string, restoreTime time.Time) (string, error) {
+	var res databasePITRRestoreRes
+	req := &httpclient.APIRequest{
+		Method:   http.MethodPost,
+		Endpoint: "/" + databasesResource + "/" + addonID + "/pitr/restore",
+		Expected: httpclient.Statuses{http.StatusCreated},
+		Params:   databasePITRRestorePayload{RestoreTime: restoreTime},
+	}
+	err := c.DBAPI(app, addonID).DoRequest(ctx, req, &res)
+	if err != nil {
+		return "", err
+	}
+
+	return res.OperationID, nil
 }

--- a/mocks_sig.json
+++ b/mocks_sig.json
@@ -10,7 +10,7 @@
   "..ContainerSizesService": "e2 db 25 a1 01 52 dc e9 6f 7b f4 59 68 95 86 b9 5e 39 8a 61",
   "..ContainersService": "ef 14 ae 81 c9 b4 6a 13 48 e8 bf 44 7d b5 b2 a6 4d e5 02 11",
   "..CronTasksService": "9b d9 a3 ca 9f 9a f7 73 cb b1 aa 80 df 90 21 ff 14 92 b4 4d",
-  "..DatabasesService": "7c 84 0b 87 60 d6 b9 c7 3a a9 53 d2 3a 1c b4 e4 46 f1 83 28",
+  "..DatabasesService": "5c 64 37 ad 77 42 06 c3 93 dd ae 69 b9 42 2a a3 73 e6 bd ba",
   "..DeploymentsService": "e1 c5 95 e5 0e 4d db 1e ec 9a 83 d8 e5 41 cc 24 ce f6 ea ba",
   "..DomainsService": "b5 19 0f 10 5b f2 48 74 c6 c2 7b 27 7d 3b b8 ff 10 80 b3 6f",
   "..EventsService": "13 7a 12 83 bf 3f 84 49 dc db 64 c3 d5 e8 4a c0 08 8c 78 f6",

--- a/scalingomock/api_mock.go
+++ b/scalingomock/api_mock.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	io "io"
 	reflect "reflect"
+	time "time"
 
 	scalingo "github.com/Scalingo/go-scalingo/v11"
 	http "github.com/Scalingo/go-scalingo/v11/http"
@@ -752,6 +753,21 @@ func (m *MockAPI) DatabaseListMaintenance(ctx context.Context, app, addonID stri
 func (mr *MockAPIMockRecorder) DatabaseListMaintenance(ctx, app, addonID, paginationReq any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseListMaintenance", reflect.TypeOf((*MockAPI)(nil).DatabaseListMaintenance), ctx, app, addonID, paginationReq)
+}
+
+// DatabasePITRRestore mocks base method.
+func (m *MockAPI) DatabasePITRRestore(ctx context.Context, app, addonID string, restoreTime time.Time) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DatabasePITRRestore", ctx, app, addonID, restoreTime)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DatabasePITRRestore indicates an expected call of DatabasePITRRestore.
+func (mr *MockAPIMockRecorder) DatabasePITRRestore(ctx, app, addonID, restoreTime any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabasePITRRestore", reflect.TypeOf((*MockAPI)(nil).DatabasePITRRestore), ctx, app, addonID, restoreTime)
 }
 
 // DatabaseShow mocks base method.

--- a/scalingomock/databasesservice_mock.go
+++ b/scalingomock/databasesservice_mock.go
@@ -7,6 +7,7 @@ package scalingomock
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	scalingo "github.com/Scalingo/go-scalingo/v11"
 	pagination "github.com/Scalingo/go-utils/pagination"
@@ -81,6 +82,21 @@ func (m *MockDatabasesService) DatabaseListMaintenance(ctx context.Context, app,
 func (mr *MockDatabasesServiceMockRecorder) DatabaseListMaintenance(ctx, app, addonID, paginationReq any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseListMaintenance", reflect.TypeOf((*MockDatabasesService)(nil).DatabaseListMaintenance), ctx, app, addonID, paginationReq)
+}
+
+// DatabasePITRRestore mocks base method.
+func (m *MockDatabasesService) DatabasePITRRestore(ctx context.Context, app, addonID string, restoreTime time.Time) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DatabasePITRRestore", ctx, app, addonID, restoreTime)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DatabasePITRRestore indicates an expected call of DatabasePITRRestore.
+func (mr *MockDatabasesServiceMockRecorder) DatabasePITRRestore(ctx, app, addonID, restoreTime any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabasePITRRestore", reflect.TypeOf((*MockDatabasesService)(nil).DatabasePITRRestore), ctx, app, addonID, restoreTime)
 }
 
 // DatabaseShow mocks base method.


### PR DESCRIPTION
A the new (existing) method to restore the PITR. Based on [this](https://developers.scalingo.com/databases/databases#point-in-time-restoration) documentation.

This will remain on draft for now, as I want to be sure that the parameters can be submit as is by the CLI. There are two questions:
- Can we submit the `app`? As it will be shared between SR and DR we need to ensure it works as expected.
- Do we want to check anything with the time?
  - Probably not as `go-scalingo` is only a wrapper, the logic will be done by the API and/or the CLI

- [x] Add a [changelog entry](https://changelog.scalingo.com/)
- [ ] QA: not done yet, as it requires the CLI to be updated

Also linked to STORY-3567.